### PR TITLE
Add To-do list web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>To-do App</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>To-do Liste</h1>
+        <nav>
+            <a href="#/">Offene Aufgaben</a>
+            <a href="#/done">Erledigte Aufgaben</a>
+        </nav>
+        <button id="themeToggle" aria-label="Theme wechseln">🌗</button>
+    </header>
+
+    <main>
+        <section id="addTaskSection">
+            <input id="taskInput" type="text" maxlength="200" placeholder="Neue Aufgabe...">
+            <select id="prioritySelect">
+                <option value="high">Hoch</option>
+                <option value="medium" selected>Mittel</option>
+                <option value="low">Niedrig</option>
+            </select>
+            <button id="addTaskBtn" disabled>Hinzufügen</button>
+        </section>
+
+        <section id="tasksSection">
+            <div class="toolbar">
+                <label>Sortieren:
+                    <select id="sortSelect">
+                        <option value="order">Reihenfolge</option>
+                        <option value="priority">Priorität</option>
+                    </select>
+                </label>
+            </div>
+            <ul id="taskList" class="task-list"></ul>
+        </section>
+
+        <section id="doneSection" hidden>
+            <ul id="doneList" class="task-list"></ul>
+        </section>
+    </main>
+
+    <template id="taskItemTemplate">
+        <li class="task-item" draggable="true" data-id="">
+            <label>
+                <input type="checkbox" class="done-checkbox" data-id="">
+                <span class="task-text"></span>
+            </label>
+            <span class="badge"></span>
+            <span class="timestamps"></span>
+            <button class="restore-btn" hidden>Wiederherstellen</button>
+        </li>
+    </template>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,244 @@
+// Hilfsfunktion zur Generierung von UUID v4
+function uuidv4() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = Math.random() * 16 | 0;
+        const v = c === 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
+
+// Zugriff auf DOM-Elemente
+const taskInput = document.getElementById('taskInput');
+const addTaskBtn = document.getElementById('addTaskBtn');
+const taskList = document.getElementById('taskList');
+const doneList = document.getElementById('doneList');
+const prioritySelect = document.getElementById('prioritySelect');
+const themeToggle = document.getElementById('themeToggle');
+const sortSelect = document.getElementById('sortSelect');
+const tasksSection = document.getElementById('tasksSection');
+const doneSection = document.getElementById('doneSection');
+const taskTemplate = document.getElementById('taskItemTemplate');
+
+let tasks = loadTasks();
+
+// Anwendung initialisieren
+initTheme();
+render();
+window.addEventListener('hashchange', render);
+if (sortSelect) sortSelect.addEventListener('change', render);
+
+// Eingabe überwachen
+taskInput.addEventListener('input', () => {
+    addTaskBtn.disabled = taskInput.value.trim().length === 0;
+});
+
+// Aufgabe hinzufügen
+addTaskBtn.addEventListener('click', () => {
+    const text = taskInput.value.trim();
+    if (!text) return;
+    const newTask = {
+        id: uuidv4(),
+        text,
+        priority: prioritySelect.value,
+        createdAt: new Date().toISOString(),
+        doneAt: null,
+        isDone: false,
+        order: tasks.filter(t => !t.isDone).length
+    };
+    tasks.push(newTask);
+    saveTasks();
+    taskInput.value = '';
+    addTaskBtn.disabled = true;
+    render();
+});
+
+// Theme wechseln
+themeToggle.addEventListener('click', () => {
+    const current = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+    document.body.dataset.theme = current;
+    localStorage.setItem('todoTheme', current);
+});
+
+// Aufgaben aus localStorage laden
+function loadTasks() {
+    try {
+        return JSON.parse(localStorage.getItem('todoTasks')) || [];
+    } catch (e) {
+        return [];
+    }
+}
+
+// Aufgaben speichern
+function saveTasks() {
+    localStorage.setItem('todoTasks', JSON.stringify(tasks));
+}
+
+// Theme initialisieren
+function initTheme() {
+    const saved = localStorage.getItem('todoTheme') || 'light';
+    document.body.dataset.theme = saved;
+}
+
+// Rendering der aktuellen Ansicht
+function render() {
+    const hash = location.hash;
+    if (hash === '#/done') {
+        tasksSection.hidden = true;
+        doneSection.hidden = false;
+        renderDone();
+    } else {
+        tasksSection.hidden = false;
+        doneSection.hidden = true;
+        renderOpen();
+    }
+}
+
+// Offene Aufgaben sortiert nach order anzeigen
+function renderOpen() {
+    taskList.innerHTML = '';
+    let openTasks = tasks.filter(t => !t.isDone);
+    if (sortSelect && sortSelect.value === 'priority') {
+        const prioMap = { high: 1, medium: 2, low: 3 };
+        openTasks.sort((a, b) => prioMap[a.priority] - prioMap[b.priority]);
+    } else {
+        openTasks.sort((a, b) => a.order - b.order);
+    }
+    openTasks.forEach(task => taskList.appendChild(createTaskItem(task)));
+}
+
+// Erledigte Aufgaben nach doneAt absteigend anzeigen
+function renderDone() {
+    doneList.innerHTML = '';
+    const doneTasks = tasks.filter(t => t.isDone).sort((a, b) => new Date(b.doneAt) - new Date(a.doneAt));
+    doneTasks.forEach(task => doneList.appendChild(createTaskItem(task, true)));
+}
+
+// Ein Task-Listeneintrag erstellen
+function createTaskItem(task, isDoneView = false) {
+    const li = taskTemplate.content.firstElementChild.cloneNode(true);
+    const textSpan = li.querySelector('.task-text');
+    const checkbox = li.querySelector('.done-checkbox');
+    const badge = li.querySelector('.badge');
+    const timestamps = li.querySelector('.timestamps');
+    const restoreBtn = li.querySelector('.restore-btn');
+
+    li.dataset.id = task.id;
+    checkbox.dataset.id = task.id;
+
+    textSpan.textContent = task.text;
+    badge.textContent = task.priority;
+    badge.classList.add(task.priority);
+    checkbox.checked = task.isDone;
+    timestamps.textContent = `erstellt: ${new Date(task.createdAt).toLocaleString()}`;
+
+    if (task.isDone) {
+        timestamps.textContent += `, erledigt: ${new Date(task.doneAt).toLocaleString()}`;
+        restoreBtn.hidden = false;
+        checkbox.style.display = 'none';
+    }
+
+    // Checkbox Handler
+    checkbox.addEventListener('change', () => {
+        task.isDone = checkbox.checked;
+        if (task.isDone) {
+            task.doneAt = new Date().toISOString();
+        } else {
+            task.doneAt = null;
+        }
+        saveTasks();
+        render();
+    });
+
+    // Restore Button
+    restoreBtn.addEventListener('click', () => {
+        task.isDone = false;
+        task.doneAt = null;
+        task.order = tasks.filter(t => !t.isDone).length;
+        saveTasks();
+        render();
+    });
+
+    // Inline Editing
+    textSpan.addEventListener('dblclick', () => startEdit(textSpan, task));
+
+    // Drag & Drop nur in offener Ansicht
+    if (!task.isDone) {
+        li.addEventListener('dragstart', e => {
+            li.classList.add('dragging');
+            e.dataTransfer.setData('text/plain', task.id);
+        });
+        li.addEventListener('dragend', () => li.classList.remove('dragging'));
+    } else {
+        li.draggable = false;
+    }
+
+    if (isDoneView) {
+        li.appendChild(restoreBtn);
+    }
+    return li;
+}
+
+// Inline Edit starten
+function startEdit(span, task) {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = task.text;
+    input.maxLength = 200;
+    span.replaceWith(input);
+    input.focus();
+
+    function cancel() {
+        input.replaceWith(span);
+    }
+
+    input.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+            task.text = input.value.trim();
+            saveTasks();
+            span.textContent = task.text;
+            input.replaceWith(span);
+        } else if (e.key === 'Escape') {
+            cancel();
+        }
+    });
+}
+
+// Drag & Drop Logik
+let dragOverId = null;
+taskList.addEventListener('dragover', e => {
+    e.preventDefault();
+    const dragging = document.querySelector('.dragging');
+    const afterElement = getDragAfterElement(e.clientY);
+    if (afterElement == null) {
+        taskList.appendChild(dragging);
+    } else {
+        taskList.insertBefore(dragging, afterElement);
+    }
+});
+
+taskList.addEventListener('drop', e => {
+    e.preventDefault();
+});
+
+function getDragAfterElement(y) {
+    const elements = [...taskList.querySelectorAll('.task-item:not(.dragging)')];
+    return elements.reduce((closest, child) => {
+        const box = child.getBoundingClientRect();
+        const offset = y - box.top - box.height / 2;
+        if (offset < 0 && offset > closest.offset) {
+            return { offset, element: child };
+        } else {
+            return closest;
+        }
+    }, { offset: Number.NEGATIVE_INFINITY }).element;
+}
+
+// Speichern der neuen Reihenfolge bei Drag & Drop Ende
+taskList.addEventListener('dragend', () => {
+    Array.from(taskList.children).forEach((li, index) => {
+        const id = li.dataset.id;
+        const task = tasks.find(t => t.id === id);
+        if (task) task.order = index;
+    });
+    saveTasks();
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,90 @@
+:root {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+    --accent-color: #6200ea;
+    --badge-high: #e53935;
+    --badge-medium: #fb8c00;
+    --badge-low: #43a047;
+}
+
+[data-theme="dark"] {
+    --bg-color: #121212;
+    --text-color: #ffffff;
+    --accent-color: #bb86fc;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    padding: 0 1rem;
+}
+
+header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 0;
+}
+
+nav a {
+    margin-right: 1rem;
+    color: var(--accent-color);
+    text-decoration: none;
+}
+
+nav a:last-child { margin-right: 0; }
+
+#addTaskSection {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+#taskInput {
+    flex: 1;
+}
+
+.task-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.task-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem;
+    border-bottom: 1px solid #ccc;
+}
+
+.task-item.dragging {
+    opacity: 0.5;
+}
+
+.badge {
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    color: #fff;
+    margin-left: 0.5rem;
+    font-size: 0.8rem;
+}
+
+.badge.high { background-color: var(--badge-high); }
+.badge.medium { background-color: var(--badge-medium); }
+.badge.low { background-color: var(--badge-low); }
+
+.restore-btn {
+    margin-left: auto;
+}
+
+.timestamps {
+    font-size: 0.75rem;
+    margin-left: 0.5rem;
+}
+
+.toolbar {
+    margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- implement a vanilla JS to-do list web app
- handle open and done views with hash routing
- store tasks in localStorage with priorities and ordering
- allow theme switching, drag/drop sorting, inline editing and restore

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845864a8d40833189ca6ae8331c107b