### PR TITLE
Align Cypress selectors with page

### DIFF
--- a/cypress/integration/f01_add_task.spec.js
+++ b/cypress/integration/f01_add_task.spec.js
@@ -6,23 +6,23 @@ describe("F-01: Aufgabe anlegen", () => {
         cy.window().then(win => win.localStorage.removeItem("todoTasks"));
     });
 
-    it("➔ #addBtn ist disabled, wenn #taskInput leer ist", () => {
+    it("➔ #addTaskBtn ist disabled, wenn #taskInput leer ist", () => {
         cy.get("#taskInput").should("have.value", "");
-        cy.get("#addBtn").should("be.disabled");
+        cy.get("#addTaskBtn").should("be.disabled");
     });
 
-    it("➔ #addBtn wird aktiv, sobald Text eingegeben wird", () => {
+    it("➔ #addTaskBtn wird aktiv, sobald Text eingegeben wird", () => {
         cy.get("#taskInput").type("Meine erste Aufgabe");
-        cy.get("#addBtn").should("not.be.disabled");
+        cy.get("#addTaskBtn").should("not.be.disabled");
     });
 
     it("➔ Aufgabe erscheint in #taskList und in localStorage", () => {
         const text = "Test-Task";
         cy.get("#taskInput").type(text);
-        cy.get("#addBtn").click();
+        cy.get("#addTaskBtn").click();
 
         // Check: Existiert genau eine li in #taskList mit diesem Text?
-        cy.get("#taskList li .text")
+        cy.get("#taskList li .task-text")
             .should("have.length", 1)
             .and("contain.text", text);
 

--- a/cypress/integration/f03_done_view.spec.js
+++ b/cypress/integration/f03_done_view.spec.js
@@ -48,10 +48,10 @@ describe("F-03: Erledigt-Ansicht", () => {
         cy.get("#taskList li").should("have.length", 3);
     });
 
-    it("➔ Jeder li hat .text, .small (erstellt+erledigt) und einen Wiederherstellen-Button", () => {
+    it("➔ Jeder li hat .text, .timestamps (erstellt+erledigt) und einen Wiederherstellen-Button", () => {
         cy.get("#taskList li").each($li => {
-            cy.wrap($li).find(".text").should("exist");
-            cy.wrap($li).find(".small").should("exist");
+            cy.wrap($li).find(".task-text").should("exist");
+            cy.wrap($li).find(".timestamps").should("exist");
             cy.wrap($li).find("button").should("exist").and("contain.text", "Wiederherstellen");
         });
     });
@@ -59,7 +59,9 @@ describe("F-03: Erledigt-Ansicht", () => {
     it("➔ Sortierung nach doneAt descending funktioniert (neuestes zuerst)", () => {
         // Das erste Element in der Liste sollte "Neue Aufgabe" sein
         cy.get("#taskList li").first().within(() => {
-            cy.get(".text").should("contain.text", "Neue Aufgabe");
+            cy.get(".task-text").should("contain.text", "Neue Aufgabe");
         });
     });
 });
+
+

--- a/cypress/integration/f04_restore_task.spec.js
+++ b/cypress/integration/f04_restore_task.spec.js
@@ -33,7 +33,7 @@ describe("F-04: Aufgabe wiederherstellen", () => {
 
         // zurück zur offenen View
         cy.get('a[href="#"]').click();
-        cy.get("#taskList li .text").should("contain.text", "Aufgabe zum Wiederherstellen");
+        cy.get("#taskList li .task-text").should("contain.text", "Aufgabe zum Wiederherstellen");
 
         // localStorage prüfen: isDone=false, doneAt=null
         cy.window().then(win => {
@@ -43,3 +43,4 @@ describe("F-04: Aufgabe wiederherstellen", () => {
         });
     });
 });
+

--- a/cypress/integration/f05_persistence.spec.js
+++ b/cypress/integration/f05_persistence.spec.js
@@ -6,7 +6,7 @@ describe("F-05: Persistenz via localStorage", () => {
 
     it("➔ Add → localStorage updaten sofort", () => {
         cy.get("#taskInput").type("Persistenz-Test");
-        cy.get("#addBtn").click();
+        cy.get("#addTaskBtn").click();
 
         cy.window().then(win => {
             const tasks = JSON.parse(win.localStorage.getItem("todoTasks"));
@@ -18,7 +18,7 @@ describe("F-05: Persistenz via localStorage", () => {
     it("➔ Toggle Done → localStorage wird geupdatet", () => {
         // 1) Task hinzufügen
         cy.get("#taskInput").type("Persistenz-Test2");
-        cy.get("#addBtn").click();
+        cy.get("#addTaskBtn").click();
 
         // 2) Task abhaken
         cy.get("#taskList li input[type='checkbox']").check();
@@ -69,16 +69,17 @@ describe("F-05: Persistenz via localStorage", () => {
 
         // 2) Offene View prüfen: zwei Tasks
         cy.get('a[href="#"]').click();
-        cy.get("#taskList li .text").should("have.length", 2);
-        cy.get("#taskList li .text").then($els => {
+        cy.get("#taskList li .task-text").should("have.length", 2);
+        cy.get("#taskList li .task-text").then($els => {
             const texts = $els.map((i, el) => Cypress.$(el).text()).get();
             expect(texts).to.include.members(["Vorhandener Offener", "Noch ein Offener"]);
         });
 
         // 3) Erledigt-View prüfen: ein Task
         cy.get('a[href="#/done"]').click();
-        cy.get("#taskList li .text")
+        cy.get("#taskList li .task-text")
             .should("have.length", 1)
             .and("contain.text", "Vorhandener Erledigter");
     });
 });
+

--- a/cypress/integration/f06_priority_badges.spec.js
+++ b/cypress/integration/f06_priority_badges.spec.js
@@ -7,7 +7,7 @@ describe("F-06: Priorität & Badges", () => {
     it("➔ Beim Erstellen kann man Priorität wählen und es wird in localStorage gespeichert", () => {
         cy.get("#taskInput").type("Priority Test");
         cy.get("#prioritySelect").select("high"); // „🔥 Hoch“
-        cy.get("#addBtn").click();
+        cy.get("#addTaskBtn").click();
 
         cy.window().then(win => {
             const tasks = JSON.parse(win.localStorage.getItem("todoTasks"));
@@ -80,9 +80,10 @@ describe("F-06: Priorität & Badges", () => {
         cy.get("#sortSelect").select("priority");
         cy.wait(200); // kurzes Warten, damit render() neu sortiert
 
-        cy.get("#taskList li .text").then($els => {
+        cy.get("#taskList li .task-text").then($els => {
             const order = $els.map((i, el) => Cypress.$(el).text()).get();
             expect(order).to.deep.equal(["High", "Medium", "Low"]);
         });
     });
 });
+

--- a/cypress/integration/f07_drag_and_drop.spec.js
+++ b/cypress/integration/f07_drag_and_drop.spec.js
@@ -59,7 +59,7 @@ describe("F-07: Drag-and-Drop Reorder (ohne Plugin)", () => {
         cy.get("#taskList li")
             .first()
             .within(() => {
-                cy.get(".text").should("contain.text", "Task B");
+                cy.get(".task-text").should("contain.text", "Task B");
             });
 
         // 8) Überprüfen: localStorage["todoTasks"] enthält B mit order=0, A mit order=1
@@ -72,3 +72,4 @@ describe("F-07: Drag-and-Drop Reorder (ohne Plugin)", () => {
         });
     });
 });
+

--- a/cypress/integration/f08_inline_edit.spec.js
+++ b/cypress/integration/f08_inline_edit.spec.js
@@ -21,20 +21,20 @@ describe("F-08: Inline-Edit", () => {
     });
 
     it("➔ Doppelklick auf .text öffnet <input> mit Werten", () => {
-        cy.get('li[data-id="edit-1"] .text').dblclick();
+        cy.get('li[data-id="edit-1"] .task-text').dblclick();
         cy.get('li[data-id="edit-1"] input[type="text"]')
             .should("exist")
             .and("have.value", "Alter Text");
     });
 
     it("➔ Enter speichert Text in localStorage & DOM", () => {
-        cy.get('li[data-id="edit-1"] .text').dblclick();
+        cy.get('li[data-id="edit-1"] .task-text').dblclick();
         cy.get('li[data-id="edit-1"] input[type="text"]')
             .clear()
             .type("Neuer Text{enter}");
 
         // DOM: Neuer Text
-        cy.get('li[data-id="edit-1"] .text').should("contain.text", "Neuer Text");
+        cy.get('li[data-id="edit-1"] .task-text').should("contain.text", "Neuer Text");
 
         // localStorage: geändert
         cy.window().then(win => {
@@ -44,13 +44,13 @@ describe("F-08: Inline-Edit", () => {
     });
 
     it("➔ Esc bricht Edit ab, Text bleibt unverändert", () => {
-        cy.get('li[data-id="edit-1"] .text').dblclick();
+        cy.get('li[data-id="edit-1"] .task-text').dblclick();
         cy.get('li[data-id="edit-1"] input[type="text"]')
             .clear()
             .type("Wrong Text{esc}");
 
         // DOM: Alter Text
-        cy.get('li[data-id="edit-1"] .text').should("contain.text", "Alter Text");
+        cy.get('li[data-id="edit-1"] .task-text').should("contain.text", "Alter Text");
 
         // localStorage: kein Change
         cy.window().then(win => {
@@ -59,3 +59,4 @@ describe("F-08: Inline-Edit", () => {
         });
     });
 });
+


### PR DESCRIPTION
## Summary
- sync Cypress selectors with DOM element names

## Testing
- `npm run cypress:run` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458c19830083319f17545723c71fd3